### PR TITLE
Update 01_maps_os_supported.yml add debian 12 support

### DIFF
--- a/roles/zabbix_agent/vars/main/01_maps_os_supported.yml
+++ b/roles/zabbix_agent/vars/main/01_maps_os_supported.yml
@@ -29,6 +29,7 @@ map_supported_os_version:
         '9': '.*'
         '10': '.*'
         '11': '.*'
+        '12': '.*'
   aarch64:
     Linux:
       Ubuntu:


### PR DESCRIPTION
No main change for Debian 12, it is the same with debian 11. The main issue is just to add in OS supported Map.