### PR TITLE
agent role verify invoke zabbix_get absolute path

### DIFF
--- a/roles/agent/tasks/verify.yml
+++ b/roles/agent/tasks/verify.yml
@@ -52,7 +52,7 @@
   register: agent_register_verify_execution_environment_get_agent_version
   # first tlsaccept value taken for connection settings
   ansible.builtin.command: >-
-      zabbix_get -k agent.version
+      /usr/bin/zabbix_get -k agent.version
       -s {{ ansible_host }}
       -t 5
       {% if driver is defined and driver in ["podman", "docker"] %}


### PR DESCRIPTION
The agent verify task should invoke `zabbix_get` using an absolute path.
Otherwise I got an error at `ansible.builtin.command` that he would not find the executable: it seems to use a very minimalistic `$PATH` at least on my environment.

Environment:
- Ubuntu 22.04.4
- ansible core 2.16.6