### PR TITLE
Add Jinja-based `hostnames` to Zabbix inventory plugin

### DIFF
--- a/changelogs/fragments/zabbix_inventory_hostnames_examples.yml
+++ b/changelogs/fragments/zabbix_inventory_hostnames_examples.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - "`zabbix_inventory` plugin: added the `hostnames` option to build inventory hostnames from ordered Jinja2 expressions with fallback to the technical Zabbix host name; duplicate rendered hostnames raise an error."
+trivial:
+  - "Added `hostnames` examples to the `zabbix_inventory` plugin documentation and plugin README."

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1533,13 +1533,58 @@ output:
   - status
 ```
 
+### Hostname examples
+
+### Example 8
+To prefer the visible host name and fall back to the technical host name, use `hostnames`.
+In this example, the first non-empty rendered value will be used as the Ansible inventory hostname.
+
+```yaml
+---
+plugin: "zabbix.zabbix.zabbix_inventory"
+
+# Set credentials.
+zabbix_api_url: http://your-zabbix.com
+zabbix_user: Admin
+zabbix_password: zabbix
+
+# Add hostname preferences.
+hostnames:
+  - '{{ name }}'
+  - '{{ host }}'
+```
+
+### Example 9
+To use the first non-empty interface DNS value and fall back to the technical host name, you can use the following example.
+
+**IMPORTANT**: Make sure that the interfaces data is requested from Zabbix API.
+
+```yaml
+---
+plugin: "zabbix.zabbix.zabbix_inventory"
+
+# Set credentials.
+zabbix_api_url: http://your-zabbix.com
+zabbix_user: Admin
+zabbix_password: zabbix
+
+# Add query for selecting interfaces from hosts. This parameter will be used for hostname generation.
+query:
+  selectInterfaces: ['dns']
+
+# Add hostname preferences.
+hostnames:
+  - '{{ zabbix_interfaces | map(attribute="dns") | select | first }}'
+  - '{{ host }}'
+```
+
 ### Postprocessing examples
 For postprocessing, you can use:
 - keyed_groups
 - groups
 - compose
 
-### Example 8
+### Example 10
 To convert the digit status to verbose, you can use `compose` from the next example.
 To group by status (enabled, disabled) from the output, you can use `groups` from the next example.
 To group by Zabbix host group, you can use `keyed_groups` from the next example.
@@ -1583,7 +1628,7 @@ keyed_groups:
     separator: ""
 ```
 
-### Example 9
+### Example 11
 For grouping by template name.
 
 ```yaml
@@ -1610,7 +1655,7 @@ keyed_groups:
     separator: ""
 ```
 
-### Example 10
+### Example 12
 For searching by the `Location` tag and grouping by tag name.
 
 ```yaml
@@ -1638,7 +1683,7 @@ keyed_groups:
     separator: ""
 ```
 
-### Example 11
+### Example 13
 For searching by the `Location` tag and grouping by tag values.
 In this example, hosts will be grouped by tag value. If you have the tags: (Location: Riga, Location: Berlin),
 then the following groups will be created: Riga, Berlin.
@@ -1668,7 +1713,7 @@ keyed_groups:
     separator: ""
 ```
 
-### Example 12
+### Example 14
 For transforming given interfaces to the list of IP addresses, you can use `compose` and the following example.
 
 ```yaml
@@ -1693,7 +1738,7 @@ compose:
   zabbix_ip_list: zabbix_interfaces | map(attribute='ip')
 ```
 
-### Example 13
+### Example 15
 For transforming given host groups to the list, you can use 'compose' and the following example.
 
 ```yaml
@@ -1718,7 +1763,7 @@ compose:
   zabbix_groups_list: zabbix_groups | map(attribute='name')
 ```
 
-### Example 14
+### Example 16
 You can use cache for inventory.
 During the loading of cached data, the plugin will compare the input parameters. If any parameters impacting the given data
 (login, password, API token, URL, output, filter, query) have been changed, then cached data will be skipped and new data will be requested from Zabbix.
@@ -1746,7 +1791,7 @@ cache_connection: /tmp/zabbix_inventory
 
 ### Complex examples
 
-### Example 15
+### Example 17
 In this example, you can use filtering by host group, template, proxy, tag, name, status.
 Grouping by Zabbix host groups.
 Transforming IP addresses to the list of IP.
@@ -1792,7 +1837,7 @@ keyed_groups:
     separator: ""
 ```
 
-### Example 16
+### Example 18
 In this example, you can apply filtering by the `Location` tag with an empty value and grouping by status (enabled, disabled).
 In the example, the status was transformed from a digit value to a verbose value and then used in `keyed_groups` for grouping by verbose statuses.
 
@@ -1834,7 +1879,7 @@ For using extra-vars, you need to meet 3 conditions:
 - specify a variable in the inventory file in 'Jinja' format. (e.g., `{{ url }}`);
 - add `--extra-vars` or `-e` with the value in the command line. (e.g., `--extra-vars url="http://localhost"`);
 
-### Example 17
+### Example 19
 To use extra-vars in your inventory file, see the example below:
 - To pass a parameter as a `list`, use the following construct: `-e macros="['macro','value']"`
 - To pass a parameter as a `dict`, use the following construct: `-e host_tag="{'tag':'My host test','value':'host 1'}"`

--- a/plugins/inventory/zabbix_inventory.py
+++ b/plugins/inventory/zabbix_inventory.py
@@ -276,6 +276,34 @@ output:
   - status
 
 
+# HOSTNAME EXAMPLES
+
+# To prefer the visible host name and fall back to the technical host name, use 'hostnames'.
+# In this example, the first non-empty rendered value will be used as the Ansible inventory hostname.
+---
+plugin: "zabbix.zabbix.zabbix_inventory"
+zabbix_api_url: http://your-zabbix.com
+zabbix_user: Admin
+zabbix_password: zabbix
+hostnames:
+  - '{{ name }}'
+  - '{{ host }}'
+
+# To use the first non-empty interface DNS value and fall back to the technical host name,
+# you can use the following example.
+# IMPORTANT: Make sure that the interfaces data is requested from Zabbix API.
+---
+plugin: "zabbix.zabbix.zabbix_inventory"
+zabbix_api_url: http://your-zabbix.com
+zabbix_user: Admin
+zabbix_password: zabbix
+query:
+  selectInterfaces: ['dns']
+hostnames:
+  - '{{ zabbix_interfaces | map(attribute="dns") | select | first }}'
+  - '{{ host }}'
+
+
 # POSTPROCESSING EXAMPLES
 
 # For postprocessing, you can use:

--- a/plugins/inventory/zabbix_inventory.py
+++ b/plugins/inventory/zabbix_inventory.py
@@ -58,6 +58,14 @@ options:
         type: str
         default: 'zabbix_'
         description: Prefix to use for parameters given from Zabbix API.
+    hostnames:
+        type: list
+        elements: str
+        description:
+            - Optional list of Jinja2 expressions to construct the Ansible inventory hostname.
+            - The first non-empty rendered value will be used.
+            - When unset, the technical host name from Zabbix (C(host)) is used.
+            - If the rendered hostname is not unique, the plugin will raise an error.
     output:
         type: list
         default: ['extend']
@@ -486,6 +494,46 @@ from ansible.utils.vars import load_extra_vars
 
 class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     NAME = 'zabbix.zabbix.zabbix_inventory'
+
+    def _get_inventory_hostname(self, host):
+        """
+        Build the Ansible inventory hostname for a Zabbix host.
+
+        If the "hostnames" option is provided, it will be evaluated as a list of
+        Jinja2 expressions. The first non-empty value wins. Otherwise, fall back
+        to the technical host name from Zabbix.
+        """
+
+        hostnames = self.args.get('hostnames') or []
+        if not hostnames:
+            return host['host']
+
+        templar_vars = dict(host)
+        prefix = self.args.get('prefix', '')
+        if prefix:
+            for key, value in host.items():
+                templar_vars['{0}{1}'.format(prefix, key)] = value
+
+        self.templar.available_variables = templar_vars
+
+        for expr in hostnames:
+            template = expr if '{{' in expr else '{{ {0} }}'.format(expr)
+            try:
+                rendered = self.templar.template(template)
+            except Exception as exc:
+                raise AnsibleParserError(
+                    'Failed to render hostname expression "{0}" for host "{1}": {2}'.format(
+                        expr, host.get('host', '<unknown>'), to_text(exc))
+                )
+
+            if rendered is None:
+                continue
+
+            candidate = to_text(rendered).strip()
+            if candidate:
+                return candidate
+
+        return host['host']
 
     def get_absolute_url(self):
         """
@@ -1141,24 +1189,37 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             self.logout()
 
         # Process data from Zabbix API / cached data
+        seen_hostnames = {}
         for host in self.zabbix_hosts:
+            inventory_hostname = self._get_inventory_hostname(host)
+
+            if self.args.get('hostnames'):
+                hostid = host.get('hostid', host.get('host'))
+                existing = seen_hostnames.get(inventory_hostname)
+                if existing is not None and existing != hostid:
+                    raise AnsibleParserError(
+                        'Duplicate inventory hostname "{0}" derived from hostids "{1}" and "{2}". '
+                        'Adjust the "hostnames" expressions to ensure uniqueness.'.format(
+                            inventory_hostname, existing, hostid)
+                    )
+                seen_hostnames[inventory_hostname] = hostid
 
             # Add data about host to inventory
-            self.inventory.add_host(host['host'])
+            self.inventory.add_host(inventory_hostname)
             for each in host:
                 self.inventory.set_variable(
-                    host['host'],
+                    inventory_hostname,
                     '{0}{1}'.format(self.args['prefix'], each),
                     host[each])
 
             # added for compose vars, keyed-groups, and composed groups
             self._set_composite_vars(
                 self.args.get('compose'),
-                self.inventory.get_host(host['host']).get_vars(),
-                host['host'],
+                self.inventory.get_host(inventory_hostname).get_vars(),
+                inventory_hostname,
                 strict=strict)
-            self._add_host_to_composed_groups(groups, dict(), host['host'], strict=strict)
-            self._add_host_to_keyed_groups(keyed_groups, dict(), host['host'], strict=strict)
+            self._add_host_to_composed_groups(groups, dict(), inventory_hostname, strict=strict)
+            self._add_host_to_keyed_groups(keyed_groups, dict(), inventory_hostname, strict=strict)
 
         # Save new data to cache
         if cache_needs_update:

--- a/plugins/inventory/zabbix_inventory.py
+++ b/plugins/inventory/zabbix_inventory.py
@@ -61,6 +61,7 @@ options:
     hostnames:
         type: list
         elements: str
+        version_added: '1.5.0'
         description:
             - Optional list of Jinja2 expressions to construct the Ansible inventory hostname.
             - The first non-empty rendered value will be used.

--- a/plugins/inventory/zabbix_inventory.py
+++ b/plugins/inventory/zabbix_inventory.py
@@ -495,7 +495,7 @@ from ansible.utils.vars import load_extra_vars
 class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     NAME = 'zabbix.zabbix.zabbix_inventory'
 
-    def _get_inventory_hostname(self, host):
+    def _get_inventory_hostname(self, host, strict=False):
         """
         Build the Ansible inventory hostname for a Zabbix host.
 
@@ -514,17 +514,21 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             for key, value in host.items():
                 templar_vars['{0}{1}'.format(prefix, key)] = value
 
-        self.templar.available_variables = templar_vars
-
+        errors = []
         for expr in hostnames:
-            template = expr if '{{' in expr else '{{ {0} }}'.format(expr)
             try:
-                rendered = self.templar.template(template)
+                stripped = expr.strip()
+                if stripped.startswith('{{') and stripped.endswith('}}'):
+                    stripped = stripped[2:-2].strip()
+                rendered = self._compose(stripped, templar_vars)
             except Exception as exc:
-                raise AnsibleParserError(
-                    'Failed to render hostname expression "{0}" for host "{1}": {2}'.format(
-                        expr, host.get('host', '<unknown>'), to_text(exc))
-                )
+                if strict:
+                    raise AnsibleParserError(
+                        'Failed to render hostname expression "{0}" for host "{1}": {2}'.format(
+                            expr, host.get('host', '<unknown>'), to_text(exc))
+                    )
+                errors.append((expr, to_text(exc)))
+                continue
 
             if rendered is None:
                 continue
@@ -532,6 +536,14 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             candidate = to_text(rendered).strip()
             if candidate:
                 return candidate
+
+        if errors:
+            raise AnsibleParserError(
+                'Could not template any hostname for host "{0}", errors for each preference: {1}'.format(
+                    host.get('host', '<unknown>'),
+                    ', '.join(['{0}: {1}'.format(pref, err) for pref, err in errors])
+                )
+            )
 
         return host['host']
 
@@ -1191,7 +1203,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         # Process data from Zabbix API / cached data
         seen_hostnames = {}
         for host in self.zabbix_hosts:
-            inventory_hostname = self._get_inventory_hostname(host)
+            inventory_hostname = self._get_inventory_hostname(host, strict=strict)
 
             if self.args.get('hostnames'):
                 hostid = host.get('hostid', host.get('host'))


### PR DESCRIPTION
Adds a `hostnames` option to `zabbix_inventory` to build `inventory_hostname` from Jinja expressions. The plugin now evaluates expressions via `Constructable._compose`, supports optional `{{ }}` wrapping, and raises a clear error on duplicate hostnames. Docs updated to describe the option and collision behavior.